### PR TITLE
Remove version numbers from <script>/npm examples.

### DIFF
--- a/developers/issuers.md
+++ b/developers/issuers.md
@@ -14,7 +14,7 @@ CHAPI integrates easily into issuer websites, allowing your site to issue Verifi
 If you're working in vanilla JavaScript, you can add the `navigator.credentials` and `credentialHandlerPolyfill` globals to your code and then load the polyfill library:
 
 ```html
-<script src="https://unpkg.com/credential-handler-polyfill/dist/credential-handler-polyfill.min.js"></script>
+<script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
 
 <script>
 await credentialHandlerPolyfill.loadOnce();
@@ -29,7 +29,7 @@ await credentialHandlerPolyfill.loadOnce();
 Or, if you're developing on Node.js, add the credential-handler-polyfill library to your project...
 
 ```sh
-npm i credential-handler-polyfill
+npm i credential-handler-polyfill@3
 ```
 
 and then import and load the polyfill library as follows:

--- a/developers/issuers.md
+++ b/developers/issuers.md
@@ -14,7 +14,7 @@ CHAPI integrates easily into issuer websites, allowing your site to issue Verifi
 If you're working in vanilla JavaScript, you can add the `navigator.credentials` and `credentialHandlerPolyfill` globals to your code and then load the polyfill library:
 
 ```html
-<script src="https://unpkg.com/credential-handler-polyfill@3.0.1/dist/credential-handler-polyfill.min.js"></script>
+<script src="https://unpkg.com/credential-handler-polyfill/dist/credential-handler-polyfill.min.js"></script>
 
 <script>
 await credentialHandlerPolyfill.loadOnce();
@@ -29,7 +29,7 @@ await credentialHandlerPolyfill.loadOnce();
 Or, if you're developing on Node.js, add the credential-handler-polyfill library to your project...
 
 ```sh
-npm i credential-handler-polyfill@3.0.1
+npm i credential-handler-polyfill
 ```
 
 and then import and load the polyfill library as follows:

--- a/developers/verifiers/index.md
+++ b/developers/verifiers/index.md
@@ -16,7 +16,7 @@ CHAPI integrates easily into verifier websites, allowing your site to request Ve
 If you're working in vanilla JavaScript, you can add the `navigator.credentials` and `credentialHandlerPolyfill` globals to your code and then load the polyfill library:
 
 ```html
-<script src="https://unpkg.com/credential-handler-polyfill/dist/credential-handler-polyfill.min.js"></script>
+<script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
 
 <script>
 await credentialHandlerPolyfill.loadOnce();
@@ -30,7 +30,7 @@ await credentialHandlerPolyfill.loadOnce();
 Or, if you're developing on Node.js, add the credential-handler-polyfill library to your project...
 
 ```sh
-npm i credential-handler-polyfill
+npm i credential-handler-polyfill@3
 ```
 
 and then import and load the polyfill library as follows:

--- a/developers/verifiers/index.md
+++ b/developers/verifiers/index.md
@@ -16,7 +16,7 @@ CHAPI integrates easily into verifier websites, allowing your site to request Ve
 If you're working in vanilla JavaScript, you can add the `navigator.credentials` and `credentialHandlerPolyfill` globals to your code and then load the polyfill library:
 
 ```html
-<script src="https://unpkg.com/credential-handler-polyfill@3.0.1/dist/credential-handler-polyfill.min.js"></script>
+<script src="https://unpkg.com/credential-handler-polyfill/dist/credential-handler-polyfill.min.js"></script>
 
 <script>
 await credentialHandlerPolyfill.loadOnce();
@@ -30,7 +30,7 @@ await credentialHandlerPolyfill.loadOnce();
 Or, if you're developing on Node.js, add the credential-handler-polyfill library to your project...
 
 ```sh
-npm i credential-handler-polyfill@3.0.1
+npm i credential-handler-polyfill
 ```
 
 and then import and load the polyfill library as follows:

--- a/developers/wallets/index.md
+++ b/developers/wallets/index.md
@@ -22,8 +22,8 @@ CHAPI integrates easily into digital wallet software, allowing your wallet to re
 If you're developing on Node.js, add the credential-handler-polyfill library to your project.  You can also install the web-credential-handler helper library to simplify your code.
 
 ```sh
-npm i credential-handler-polyfill
-npm i web-credential-handler
+npm i credential-handler-polyfill@3
+npm i web-credential-handler@2
 ```
 
 In your code, you can import and load the polyfill library as follows:

--- a/developers/wallets/index.md
+++ b/developers/wallets/index.md
@@ -22,8 +22,8 @@ CHAPI integrates easily into digital wallet software, allowing your wallet to re
 If you're developing on Node.js, add the credential-handler-polyfill library to your project.  You can also install the web-credential-handler helper library to simplify your code.
 
 ```sh
-npm i credential-handler-polyfill@3.0.1
-npm i web-credential-handler@2.0.1
+npm i credential-handler-polyfill
+npm i web-credential-handler
 ```
 
 In your code, you can import and load the polyfill library as follows:


### PR DESCRIPTION
Too hard to keep these accurate over time.