### PR TITLE
Fix missing markdown features

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 const sass = require('sass');
 const markdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
+const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
 module.exports = function(eleventyConfig) {
   /* Markdown Overrides */
@@ -12,6 +13,8 @@ module.exports = function(eleventyConfig) {
     permalink: false
   });
   eleventyConfig.setLibrary('md', markdownLibrary);
+
+  eleventyConfig.addPlugin(syntaxHighlight);
 
   eleventyConfig.addTemplateFormats('scss');
   // Creates the extension for use

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,18 @@
 const sass = require('sass');
+const markdownIt = require('markdown-it');
+const markdownItAnchor = require('markdown-it-anchor');
 
 module.exports = function(eleventyConfig) {
+  /* Markdown Overrides */
+  const markdownLibrary = markdownIt({
+    html: true,
+    breaks: true,
+    linkify: true
+  }).use(markdownItAnchor, {
+    permalink: false
+  });
+  eleventyConfig.setLibrary('md', markdownLibrary);
+
   eleventyConfig.addTemplateFormats('scss');
   // Creates the extension for use
   eleventyConfig.addExtension('scss', {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link href="https://unpkg.com/prismjs@1/themes/prism.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.9.2/dist/semantic.min.css">
     <link rel="stylesheet" href="/assets/css/style.css">
   </head>

--- a/_layouts/subpage.html
+++ b/_layouts/subpage.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link href="https://unpkg.com/prismjs@1/themes/prism.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.9.2/dist/semantic.min.css">
     <link rel="stylesheet" href="/assets/css/style.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@11ty/eleventy": "^2.0.1"
   },
   "dependencies": {
+    "markdown-it-anchor": "^8.6.7",
     "sass": "^1.66.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "author": "Digital Bazaar, Inc.",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@11ty/eleventy": "^2.0.1"
+    "@11ty/eleventy": "^2.0.1",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0"
   },
   "dependencies": {
     "markdown-it-anchor": "^8.6.7",


### PR DESCRIPTION
I'd forgotten just how "batteries included" Jekyll + GitHub Pages was... This brings back code highlighting and the _essential_ header anchor links.