### PR TITLE
Native wallets

### DIFF
--- a/_layouts/subpage.html
+++ b/_layouts/subpage.html
@@ -69,6 +69,7 @@
       $('.ui.sidebar')
         .sidebar('attach events', '.toc.item');
     </script>
+    <script src="/assets/js/tabs.js"></script>
 
   </body>
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -87,3 +87,52 @@ header .right.menu .toc.item {
 //Code box annotation
 .code-annotation { margin-top: -1rem; color: #777d83; text-align:right; font-size: 0.9rem;  
   a {color: #777d83;} }
+
+  .tab {
+    display: flex;
+    flex-wrap: wrap;
+    margin-left: -20px;
+    padding: 0;
+    list-style: none;
+    position: relative;
+}
+
+.tab > * {
+    flex: none;
+    padding-left: 20px;
+    position: relative;
+}
+
+.tab > * > a {
+    display: block;
+    text-align: center;
+    padding: 9px 20px;
+    color: #999;
+    border-bottom: 2px solid transparent;
+    border-bottom-color: transparent;
+    font-size: 12px;
+    text-transform: uppercase;
+    transition: color .1s ease-in-out;
+    line-height: 20px;
+}
+
+.tab > .active > a {
+    color:#222;
+    border-color: #1e87f0;
+}
+
+.tab > li > a {
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.tab-content {
+    padding: 0;
+}
+
+.tab-content > li {
+    display: none;
+}
+.tab-content > li.active {
+    display: initial;
+}

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -1,0 +1,181 @@
+/**
+ * Configure the tabs behavior.
+ */
+const jekyllTabsConfiguration = {
+  syncTabsWithSameLabels: false,
+  addCopyToClipboardButton: false,
+  copyToClipboardButtonHtml: '<button>Copy</button>',
+};
+
+const jekyllTabsModule = (function() {
+
+  /**
+   * Remove all "active" classes on li elements that belong to the given ul element.
+   */
+  const removeActiveClasses = function (ulElement) {
+      const liElements = ulElement.querySelectorAll('ul > li');
+
+      Array.prototype.forEach.call(liElements, function(liElement) {
+          liElement.classList.remove('active');
+      });
+  }
+
+  /**
+   * Get the element position looking from the perspective of the parent element.
+   *
+   * Considering the following html:
+   *
+   * <ul>
+   *   <li class="zero">0</li>
+   *   <li class="one">1</li>
+   *   <li class="two">2</li>
+   * </ul>
+   *
+   * Then getChildPosition(document.querySelector('.one')) would return 1.
+   */
+  const getChildPosition = function (element) {
+      var parent = element.parentNode;
+      var i = 0;
+      for (var i = 0; i < parent.children.length; i++) {
+          if (parent.children[i] === element) {
+              return i;
+          }
+      }
+
+      throw new Error('No parent found');
+  }
+
+  /**
+   * Returns a list of elements of the given tag that contains the given text.
+   */
+  const findElementsContaining = function(elementTag, text) {
+      const elements = document.querySelectorAll(elementTag);
+      const elementsThatContainText = [];
+
+      for (let i = 0; i < elements.length; i++) {
+          const element = elements[i];
+
+          if (element.textContent.includes(text)) {
+              elementsThatContainText.push(element);
+          }
+      }
+
+      return elementsThatContainText;
+  }
+
+  /**
+   * Handle adding or removing active classes on tab list items.
+   */
+  const handleTabClicked = function(link) {
+      liTab = link.parentNode;
+      ulTab = liTab.parentNode;
+      liPositionInUl = getChildPosition(liTab);
+
+      if (liTab.className.includes('active')) {
+          return;
+      }
+
+      tabContentId = ulTab.getAttribute('data-tab');
+      tabContentElement = document.getElementById(tabContentId);
+
+      // Remove all "active" classes first.
+      removeActiveClasses(ulTab);
+      removeActiveClasses(tabContentElement);
+
+      // Then add back active classes depending on the tab (ul element) that was clicked on.
+      tabContentElement.querySelectorAll(':scope > li')[liPositionInUl].classList.add('active');
+      liTab.classList.add('active');
+  }
+
+  /**
+   * Create a javascript element from html markup.
+   */
+  const createElementFromHtml = function(html) {
+      const template = document.createElement('template');
+      template.innerHTML = html.trim();
+
+      return template.content.firstChild;
+  }
+
+  /**
+   * Copy the given text in the clipboard.
+   *
+   * See https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined
+   */
+  const copyToClipboard = function(text) {
+      if (navigator.clipboard && window.isSecureContext) {
+          navigator.clipboard.writeText(text);
+      } else {
+          // Use the 'out of viewport hidden text area' trick
+          const textArea = document.createElement("textarea");
+          textArea.value = text;
+
+          // Move textarea out of the viewport so it's not visible
+          textArea.style.position = "absolute";
+          textArea.style.left = "-999999px";
+
+          document.body.prepend(textArea);
+          textArea.select();
+
+          try {
+              document.execCommand('copy');
+          } catch (error) {
+              console.error(error);
+          } finally {
+              textArea.remove();
+          }
+      };
+  }
+
+  return {
+      findElementsContaining,
+      handleTabClicked,
+      createElementFromHtml,
+      copyToClipboard,
+  };
+
+})();
+
+window.addEventListener('load', function () {
+  const tabLinks = document.querySelectorAll('ul.tab > li > a');
+
+  Array.prototype.forEach.call(tabLinks, function(link) {
+      link.addEventListener('click', function (event) {
+          event.preventDefault();
+
+          jekyllTabsModule.handleTabClicked(link);
+
+          if (jekyllTabsConfiguration.syncTabsWithSameLabels) {
+              const linksWithSameName = jekyllTabsModule.findElementsContaining('a', link.textContent);
+
+              for(let i = 0; i < linksWithSameName.length; i++) {
+                  if (linksWithSameName[i] !== link) {
+                      jekyllTabsModule.handleTabClicked(linksWithSameName[i]);
+                  }
+              }
+          }
+      }, false);
+  });
+
+  if (jekyllTabsConfiguration.addCopyToClipboardButton) {
+      const preElements = document.querySelectorAll('ul.tab-content > li pre');
+
+      for(let i = 0; i < preElements.length; i++) {
+          const preElement = preElements[i];
+          const preParentNode = preElement.parentNode;
+          const button = jekyllTabsModule.createElementFromHtml(jekyllTabsConfiguration.copyToClipboardButtonHtml);
+
+          preParentNode.style.position = 'relative';
+          button.style.position = 'absolute';
+          button.style.top = '0px';
+          button.style.right = '0px';
+
+          preParentNode.appendChild(button);
+
+          button.addEventListener('click', function () {
+              jekyllTabsModule.copyToClipboard(preElement.innerText);
+          });
+      }
+  }
+
+});

--- a/developers/wallets/index.md
+++ b/developers/wallets/index.md
@@ -6,13 +6,20 @@ permalink: /developers/wallets/
 # CHAPI for Digital Wallets
 CHAPI integrates easily into digital wallet software, allowing your wallet to receive and present Verifiable Credentials to/from third party sites.
 
+## Web Wallets
+
 * [Wallet Registration](#wallet-registration)
 * [VC Storage](#vc-storage)
 * [VC Retrieval](#vc-retrieval)
 * [DID Authentication with CHAPI](#did-authentication-with-chapi)
-* [Working with `QueryByExample` format requests](querybyexample)
+
+## Native Wallets
+* [Wallet Registration](native/#wallet-registration)
+* [VC Storage](native/#vc-storage)
 
 ## Resources
+
+* [Working with `QueryByExample` format requests](querybyexample)
 - **Example Code**: the [chapi-demo-wallet](https://github.com/credential-handler/chapi-demo-wallet) contains a full example implementation and is referenced throughout this guide.
 - **Polyfill Library**: The [credential-handler-polyfill](https://github.com/credential-handler/credential-handler-polyfill) library provides the needed functionality in the browser.
 - **Helper Library**: The [web-credential-handler](https://github.com/credential-handler/web-credential-handler) library provides helper functions for CHAPI integration in your code.
@@ -20,10 +27,6 @@ CHAPI integrates easily into digital wallet software, allowing your wallet to re
 ## Wallet Registration
 
 Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials.
-
-{% tabs wallet %}
-
-{% tab wallet for web wallets %}
 
 ### 1. Import the CHAPI Polyfill into your wallet app
 If you're developing on Node.js, add the credential-handler-polyfill library to your project.  You can also install the web-credential-handler helper library to simplify your code.
@@ -96,84 +99,9 @@ WebCredentialHandler.activateHandler({
   target="_blank" rel="noopener noreferrer"> chapi-demo-wallet/wallet-worker.html </a>
 </p>
 
-
-{% endtab %}
-
-{% tab wallet for native mobile wallets %}
-
-To enable a native mobile wallet to receive VCs via CHAPI, your application will need to be able to handle deeplinks. See appropriate deep link documentation for [Android](https://developer.android.com/training/app-links/deep-linking) or [iOS](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content?language=objc).
-
-During this process you will be required to host the appropriate operating system specific files on a web server. To enable CHAPI registration this web server will also need to host a page that allows the user to register the CHAPI handler with the mobile web browser.
-
-### 1. Import the CHAPI Polyfill into the page
-
-```html
-<script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
-
-<script>
-  await credentialHandlerPolyfill.loadOnce();
-</script>
-```
-
-### 2. Add a `credential_handler` to the server's manifest.json
-
-In order to register a credential handler, your registration page's server must serve a "manifest.json" file from its root path ("/manifest.json"). This file must also be CORS-enabled. Add the following `credential_handler` object with the appropriate `acceptedProtocols` your wallet will handle:
-
-```json
-{
-  "credential_handler": {
-    "url": "/worker",
-    "enabledTypes": ["VerifiablePresentation"],
-    "acceptedInput": "url",
-    "acceptedProtocols": [
-      "OID4VCI",
-      "OID4VP",
-      "vcapi"
-    ]
-  }
-}
-```
-
-The `url` property will be the entry point for your mobile wallet so it must be a deeplink that will open the application. The details about the event that initiated this action will be relayed via query parameters.
-
-The `acceptedInput` property is what tells CHAPI that the wallet receives data through URL and query parameters rather than events like a web wallet does.
-
-### 3. Allow your users to register their wallet's credential handler with the browser polyfill
-
-Add to your registration page the ability for a user to register the wallet as a Credential Handler. This must be initiated by user interaction so you cannot automatically register without the user clicking a button.
-
-```html
-<button id="installHandlerButton">Register Wallet</button>
-
-<script src="https://unpkg.com/web-credential-handler@2/dist/web-credential-handler.min.js"></script>
-
-<script>
-  document.getElementById('installHandlerButton').addEventListener('click', async function() {
-    try {
-      await WebCredentialHandler.installHandler();
-      console.log('Handler Installed Successfully!');
-    } catch (error) {
-      console.error('Error installing handler: ' + error.message);
-    }
-  });
-</script>
-```
-
-### 4. Link users to the registration page from your application
-
-After this registration page is up and running your mobile application can include a link to it that will open the devices browser to the registration page and allow them to register the wallet as a Credential Handler.
-
-{% endtab %}
-
-{% endtabs %}
-
 ## VC Storage
 
 Wallets are able to store Verifiable Credentials issued by third-party websites using CHAPI.
-
-{% tabs storage %}
-
-{% tab storage for web wallets %}
 
 ### Store Credentials Events
 
@@ -194,47 +122,9 @@ async function handleStoreEvent() {
 
 Storage of credentials prompts the individual using the browser to confirm that they want to store the credential in their digital wallet.
 
-{% endtab %}
-
-{% tab storage for native mobile wallets %}
-
-There are currently two possible protocols that issuers may use with CHAPI in order to issue Verifiable Credentials and have them stored in the user's digital wallet. When the application lands on the page specified in the `url` property of the `credential_handler` in the `manifest.json` file there will be a `request` query parameter that will include a URL encoded object with the following properties:
-
-- `credentialRequestOrigin`: This will tell the wallet where the request originated
-- `protocols`: This will include any available credential issuance protocols. The wallet may retrieve the credential for storage from any of the available protocols.
-
-Example URL that includes both `vcapi` as well as `OID4VCI` issuance protocols.
-
-`https://wallet.example.com/worker?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D`
-
-
-### VC-API
-
-If the protocols property from the request contains a `vcapi` property it will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `GET` request to this URL to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details. 
-
-See the [VC API Specification](https://w3c-ccg.github.io/vc-api/) for more details on this protocol.
-
-Example VCAPI protocol URL:
-`https://exchanger.example.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z19mxa763DAKX7diL51kBFecZ`
-
-### OID4VCI
-
-If the protocols property from the request contains a `OID4VCI` property it will be a URL that will include all of the required information to complete the issuance of the Verifiable Credential using the OID4VCI protocol. See the [OID4VCI Specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) for more details of this protocol.
-
-Example OID4VCI protocol URL:
-`openid-credential-offer://?credential_offer={"credential_issuer":"https://qa.veresexchanger.dev/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z1A36rr6wEL25EEiikKvisVEC","credentials":[{"format":"ldp_vc","credential_definition":{"@context":["https://www.w3.org/2018/credentials/v1","https://purl.imsglobal.org/spec/ob/v3p0/context.json"],"type":["VerifiableCredential","OpenBadgeCredential"]}}],"grants":{"urn:ietf:params:oauth:grant-type:pre-authorized_code":{"pre-authorized_code":"0065a8a0-069b-46f1-a857-4e1ce5047afd"}}}`
-
-{% endtab %}
-
-{% endtabs %}
-
 ## VC Retrieval
 
 Wallets are able to present Verifiable Credentials to third-party websites using CHAPI. 
-
-{% tabs retrieval %}
-
-{% tab retrieval for web wallets %}
 
 ### Get Credentials Events
 CHAPI supports the presentation of credentials via the `navigator.credentials.get()` API. CHAPI is agnostic to the presentation request query language and passes the query directly through to the credential handler. If you've configured an event listener, you can follow the example below to call the relevant code in your wallet whenever it receives a CHAPI `get()` request from a third-party website.
@@ -255,16 +145,6 @@ CHAPI supports the presentation of credentials via the `navigator.credentials.ge
 </p>
 
 When presenting credentials, the user is shown what they will be sharing and must provide explicit consent before the credentials are shared with the requesting party.
-
-{% endtab %}
-
-{% tab retrieval for native mobile wallets %}
-
-TODO
-
-{% endtab %}
-
-{% endtabs %}
 
 ## DID Authentication with CHAPI
 This section is written from the perspective of web wallets.  CHAPI provides a simple method for a 3rd party website to request an individual present their Decentralized Identifier (DID) and prove their identity.  The individual selects a digital wallet to respond to this DID Authentication request.

--- a/developers/wallets/index.md
+++ b/developers/wallets/index.md
@@ -134,9 +134,14 @@ In order to register a credential handler, your registration page's server must 
 }
 ```
 
-The `url` will be the entry point for your mobile wallet so it must be a deeplink that will open the application. The details about the event that initiated this action will be relayed via query parameters.
+The `url` property will be the entry point for your mobile wallet so it must be a deeplink that will open the application. The details about the event that initiated this action will be relayed via query parameters.
+
+The `acceptedInput` property is what tells CHAPI that the wallet receives data through URL and query parameters rather than events like a web wallet does.
 
 ### 3. Allow your users to register their wallet's credential handler with the browser polyfill
+
+Add to your registration page the ability for a user to register the wallet as a Credential Handler. This must be initiated by user interaction so you cannot automatically register without the user clicking a button.
+
 ```html
 <button id="installHandlerButton">Register Wallet</button>
 
@@ -156,7 +161,7 @@ The `url` will be the entry point for your mobile wallet so it must be a deeplin
 
 ### 4. Link users to the registration page from your application
 
-After this registration page is up and running your mobile application can include a link to it that will open the devices browser to the registration page and allow the wallet to be registered as a Credential Handler.
+After this registration page is up and running your mobile application can include a link to it that will open the devices browser to the registration page and allow them to register the wallet as a Credential Handler.
 
 {% endtab %}
 
@@ -198,13 +203,26 @@ There are currently two possible protocols that issuers may use with CHAPI in or
 - `credentialRequestOrigin`: This will tell the wallet where the request originated
 - `protocols`: This will include any available credential issuance protocols. The wallet may retrieve the credential for storage from any of the available protocols.
 
+Example URL that includes both `vcapi` as well as `OID4VCI` issuance protocols.
+
+`https://wallet.example.com/worker?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D`
+
+
 ### VC-API
 
-If the protocols property from the request contains a `vcapi` property it will be a URL that will tell the wallet where to go to retrieve the credential. See the [VC API Specification](https://w3c-ccg.github.io/vc-api/) for more details on this protocol.
+If the protocols property from the request contains a `vcapi` property it will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `GET` request to this URL to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details. 
+
+See the [VC API Specification](https://w3c-ccg.github.io/vc-api/) for more details on this protocol.
+
+Example VCAPI protocol URL:
+`https://exchanger.example.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z19mxa763DAKX7diL51kBFecZ`
 
 ### OID4VCI
 
 If the protocols property from the request contains a `OID4VCI` property it will be a URL that will include all of the required information to complete the issuance of the Verifiable Credential using the OID4VCI protocol. See the [OID4VCI Specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) for more details of this protocol.
+
+Example OID4VCI protocol URL:
+`openid-credential-offer://?credential_offer={"credential_issuer":"https://qa.veresexchanger.dev/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z1A36rr6wEL25EEiikKvisVEC","credentials":[{"format":"ldp_vc","credential_definition":{"@context":["https://www.w3.org/2018/credentials/v1","https://purl.imsglobal.org/spec/ob/v3p0/context.json"],"type":["VerifiableCredential","OpenBadgeCredential"]}}],"grants":{"urn:ietf:params:oauth:grant-type:pre-authorized_code":{"pre-authorized_code":"0065a8a0-069b-46f1-a857-4e1ce5047afd"}}}`
 
 {% endtab %}
 

--- a/developers/wallets/index.md
+++ b/developers/wallets/index.md
@@ -9,13 +9,13 @@ CHAPI integrates easily into digital wallet software, allowing your wallet to re
 ## Web Wallets
 
 * [Wallet Registration](#wallet-registration)
-* [VC Storage](#vc-storage)
-* [VC Retrieval](#vc-retrieval)
+* [Verifiable Credential Storage](#verifiable-credential-storage)
+* [Verifiable Credential Presentation](#verifiable-credential-presentation)
 * [DID Authentication with CHAPI](#did-authentication-with-chapi)
 
 ## Native Wallets
 * [Wallet Registration](native/#wallet-registration)
-* [VC Storage](native/#vc-storage)
+* [Verifiable Credential Storage](native/#verifiable-credential-storage)
 
 ## Resources
 
@@ -99,7 +99,7 @@ WebCredentialHandler.activateHandler({
   target="_blank" rel="noopener noreferrer"> chapi-demo-wallet/wallet-worker.html </a>
 </p>
 
-## VC Storage
+## Verifiable Credential Storage
 
 Wallets are able to store Verifiable Credentials issued by third-party websites using CHAPI.
 
@@ -112,7 +112,7 @@ async function handleStoreEvent() {
     const event = await WebCredentialHandler.receiveCredentialEvent();
     console.log('Store Credential Event:', event.type, event);
 
-    //Your wallet's code for storing a Verifiable Credential
+    // Your wallet's code for storing a Verifiable Credentials
 }
 ```
 <p class="code-annotation">
@@ -122,7 +122,7 @@ async function handleStoreEvent() {
 
 Storage of credentials prompts the individual using the browser to confirm that they want to store the credential in their digital wallet.
 
-## VC Retrieval
+## Verifiable Credential Presentation
 
 Wallets are able to present Verifiable Credentials to third-party websites using CHAPI. 
 
@@ -144,7 +144,7 @@ CHAPI supports the presentation of credentials via the `navigator.credentials.ge
   target="_blank" rel="noopener noreferrer"> chapi-demo-wallet/wallet-ui-get.html </a>
 </p>
 
-When presenting credentials, the user is shown what they will be sharing and must provide explicit consent before the credentials are shared with the requesting party.
+When credentials are requested, wallets should show the user what will be shared and require the user's explicit consent before the credentials are presented to the requesting party.
 
 ## DID Authentication with CHAPI
 This section is written from the perspective of web wallets.  CHAPI provides a simple method for a 3rd party website to request an individual present their Decentralized Identifier (DID) and prove their identity.  The individual selects a digital wallet to respond to this DID Authentication request.

--- a/developers/wallets/index.md
+++ b/developers/wallets/index.md
@@ -26,7 +26,7 @@ CHAPI integrates easily into digital wallet software, allowing your wallet to re
 
 ## Wallet Registration
 
-Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials.
+Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials on the Web.
 
 ### 1. Import the CHAPI Polyfill into your wallet app
 If you're developing on Node.js, add the credential-handler-polyfill library to your project.  You can also install the web-credential-handler helper library to simplify your code.

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -29,29 +29,16 @@ Deep links, also known as app links, cause a user's Web browser to open a native
 
 Consequently, you will be required by the mobile OS to host the appropriate operating system specific files on a Web server.
 
-In addition, to enable CHAPI registration, your Web server will also need to host a page that allows the user to register your wallet with CHAPI within their mobile Web browser.
+In addition, to enable CHAPI registration, your Web server will also need to host a `manifest.json` file as well as a registration page that allows the user to register your wallet with CHAPI within their mobile Web browser.
 
-### 1. Import the CHAPI Polyfill into the page
-
-The page that receives the deep link must include the CHAPI Polyfill to liaison
-the registration of your Native Wallet with your user's browser:
-
-```html
-<script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
-
-<script>
-  await credentialHandlerPolyfill.loadOnce();
-</script>
-```
-
-### 2. Add a `credential_handler` to the server's `manifest.json`
+### 1. Add a `credential_handler` to the server's `manifest.json`
 
 In order to register as a Credential Handler, your registration page's server must serve a `manifest.json` file from its root path (`/manifest.json`). This endpoint must also be CORS-enabled. Add the following `credential_handler` object with the appropriate `acceptedProtocols` your wallet can handle:
 
 ```json
 {
   "credential_handler": {
-    "url": "/worker",
+    "url": "/switchboard",
     "enabledTypes": ["VerifiablePresentation"],
     "acceptedInput": "url",
     "acceptedProtocols": [
@@ -67,7 +54,7 @@ The `url` property must be the entry point for your mobile wallet so it must be 
 
 The `"acceptedInput": "url"` line tells CHAPI that the wallet should receive data via opening the URL and providing query parameters rather than browser sent events typically used with Web wallets.
 
-### 3. Allow your users to register their wallet as a Credential Handler with the browser polyfill
+### 2. Allow your users to register their wallet as a Credential Handler with the browser polyfill
 
 Next, we need to have the user trigger the registration of your wallet as a Credential Handler within their browser. This must be initiated by user interaction, so you cannot automatically register without the user clicking a button.
 
@@ -76,9 +63,12 @@ Add something similar to your registration page:
 ```html
 <button id="installHandlerButton">Register Wallet</button>
 
+<script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
 <script src="https://unpkg.com/web-credential-handler@2/dist/web-credential-handler.min.js"></script>
 
 <script>
+  await credentialHandlerPolyfill.loadOnce();
+
   document.getElementById('installHandlerButton').addEventListener('click', async function() {
     try {
       await WebCredentialHandler.installHandler();
@@ -90,7 +80,7 @@ Add something similar to your registration page:
 </script>
 ```
 
-### 4. Link users to the registration page from your application
+### 3. Link users to the registration page from your application
 
 Your mobile application should include a link to your registration page. That link should open the device's default browser and allow them to register the wallet as a Credential Handler.
 

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -21,9 +21,9 @@ permalink: /developers/wallets/native/
 
 ## Wallet Registration
 
-Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials.
+Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials on the Web.
 
-To enable a native mobile wallet to receive VCs via CHAPI, your application will need to be able to handle deeplinks. See appropriate deep link documentation for [Android](https://developer.android.com/training/app-links/deep-linking) or [iOS](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content?language=objc).
+To enable a native mobile wallet to receive VCs via CHAPI, your application will need to be able to handle deep links. Deep links, also known as app links, cause a user's Web browser to open a native application and pass the URL to it when particular links are followed. This enables the user's Web browser to open a native mobile wallet from the CHAPI wallet selection menu and pass the CHAPI request to it. See appropriate deep link documentation for [Android](https://developer.android.com/training/app-links/deep-linking) or [iOS](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content?language=objc).
 
 During this process you will be required to host the appropriate operating system specific files on a web server. To enable CHAPI registration this web server will also need to host a page that allows the user to register the CHAPI handler with the mobile web browser.
 

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -1,0 +1,114 @@
+---
+layout: subpage
+title: "Developer Docs for Native Wallet Applications"
+permalink: /developers/wallets/native/
+---
+
+[Back to Wallet Documentation](../)
+
+# Native Wallets
+
+* [Wallet Registration](#wallet-registration)
+* [VC Storage](#vc-storage)
+
+## Resources
+
+* [Working with `QueryByExample` format requests](querybyexample)
+- **Example Code**: the [chapi-demo-wallet](https://github.com/credential-handler/chapi-demo-wallet) contains a full example implementation and is referenced throughout this guide.
+- **Polyfill Library**: The [credential-handler-polyfill](https://github.com/credential-handler/credential-handler-polyfill) library provides the needed functionality in the browser.
+- **Helper Library**: The [web-credential-handler](https://github.com/credential-handler/web-credential-handler) library provides helper functions for CHAPI integration in your code.
+
+
+## Wallet Registration
+
+Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials.
+
+To enable a native mobile wallet to receive VCs via CHAPI, your application will need to be able to handle deeplinks. See appropriate deep link documentation for [Android](https://developer.android.com/training/app-links/deep-linking) or [iOS](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content?language=objc).
+
+During this process you will be required to host the appropriate operating system specific files on a web server. To enable CHAPI registration this web server will also need to host a page that allows the user to register the CHAPI handler with the mobile web browser.
+
+### 1. Import the CHAPI Polyfill into the page
+
+```html
+<script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
+
+<script>
+  await credentialHandlerPolyfill.loadOnce();
+</script>
+```
+
+### 2. Add a `credential_handler` to the server's manifest.json
+
+In order to register a credential handler, your registration page's server must serve a "manifest.json" file from its root path ("/manifest.json"). This file must also be CORS-enabled. Add the following `credential_handler` object with the appropriate `acceptedProtocols` your wallet will handle:
+
+```json
+{
+  "credential_handler": {
+    "url": "/worker",
+    "enabledTypes": ["VerifiablePresentation"],
+    "acceptedInput": "url",
+    "acceptedProtocols": [
+      "OID4VCI",
+      "OID4VP",
+      "vcapi"
+    ]
+  }
+}
+```
+
+The `url` property will be the entry point for your mobile wallet so it must be a deeplink that will open the application. The details about the event that initiated this action will be relayed via query parameters.
+
+The `acceptedInput` property is what tells CHAPI that the wallet receives data through URL and query parameters rather than events like a web wallet does.
+
+### 3. Allow your users to register their wallet's credential handler with the browser polyfill
+
+Add to your registration page the ability for a user to register the wallet as a Credential Handler. This must be initiated by user interaction so you cannot automatically register without the user clicking a button.
+
+```html
+<button id="installHandlerButton">Register Wallet</button>
+
+<script src="https://unpkg.com/web-credential-handler@2/dist/web-credential-handler.min.js"></script>
+
+<script>
+  document.getElementById('installHandlerButton').addEventListener('click', async function() {
+    try {
+      await WebCredentialHandler.installHandler();
+      console.log('Handler Installed Successfully!');
+    } catch (error) {
+      console.error('Error installing handler: ' + error.message);
+    }
+  });
+</script>
+```
+
+### 4. Link users to the registration page from your application
+
+After this registration page is up and running your mobile application can include a link to it that will open the devices browser to the registration page and allow them to register the wallet as a Credential Handler.
+
+## VC Storage
+
+There are currently two possible protocols that issuers may use with CHAPI in order to issue Verifiable Credentials and have them stored in the user's digital wallet. When the application lands on the page specified in the `url` property of the `credential_handler` in the `manifest.json` file there will be a `request` query parameter that will include a URL encoded object with the following properties:
+
+- `credentialRequestOrigin`: This will tell the wallet where the request originated
+- `protocols`: This will include any available credential issuance protocols. The wallet may retrieve the credential for storage from any of the available protocols.
+
+Example URL that includes both `vcapi` as well as `OID4VCI` issuance protocols.
+
+`https://wallet.example.com/worker?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D`
+
+
+### VC-API
+
+If the protocols property from the request contains a `vcapi` property it will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `GET` request to this URL to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details. 
+
+See the [VC API Specification](https://w3c-ccg.github.io/vc-api/) for more details on this protocol.
+
+Example VCAPI protocol URL:
+`https://exchanger.example.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z19mxa763DAKX7diL51kBFecZ`
+
+### OID4VCI
+
+If the protocols property from the request contains a `OID4VCI` property it will be a URL that will include all of the required information to complete the issuance of the Verifiable Credential using the OID4VCI protocol. See the [OID4VCI Specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) for more details of this protocol.
+
+Example OID4VCI protocol URL:
+`openid-credential-offer://?credential_offer={"credential_issuer":"https://qa.veresexchanger.dev/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z1A36rr6wEL25EEiikKvisVEC","credentials":[{"format":"ldp_vc","credential_definition":{"@context":["https://www.w3.org/2018/credentials/v1","https://purl.imsglobal.org/spec/ob/v3p0/context.json"],"type":["VerifiableCredential","OpenBadgeCredential"]}}],"grants":{"urn:ietf:params:oauth:grant-type:pre-authorized_code":{"pre-authorized_code":"0065a8a0-069b-46f1-a857-4e1ce5047afd"}}}`

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -9,7 +9,7 @@ permalink: /developers/wallets/native/
 # Native Wallets
 
 * [Wallet Registration](#wallet-registration)
-* [VC Storage](#vc-storage)
+* [Verifiable Credential Storage](#verifiable-credential-storage)
 
 ## Resources
 
@@ -90,10 +90,10 @@ Once done, your Wallet should now be enabled to handle various credential relate
 
 Now that your native wallet has been registered with CHAPI, it can receive requests to store credentials at the URL stated in the `credential_handler.url` of the `manifest.json` above.
 
-The endpoint declared there (i.e. `/switchboard`) will receive a `request` query parameter that will include a URL encoded object with the following properties:
+The endpoint declared there (`/switchboard` in the example above) will receive a `request` query parameter that will include a URL encoded object with the following properties:
 
 - `credentialRequestOrigin`: This will tell the wallet where the request originated
-- `protocols`: This will include any available credential issuance protocols. The wallet may retrieve the credential for storage from any of the available protocols.
+- `protocols`: This will include any available credential exchange protocols (for issuance and/or presentation). The wallet may retrieve the credential for storage from any of the available protocols.
 
 Here is an example URL showing the `request` query parameter and its URL encoded value:
 
@@ -102,7 +102,7 @@ https://wallet.example.com/switchboard
   ?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D
 </code></pre>
 
-The `request` value is URL encoded. It's contents look like this when unencoded:
+The `request` value is URL encoded. Its contents look like this when unencoded:
 
 ```json
 {
@@ -116,11 +116,11 @@ The `request` value is URL encoded. It's contents look like this when unencoded:
 
 There are currently two possible protocols that Issuers may use with CHAPI in order to issue Verifiable Credentials to be stored in the user's digital wallet: `vcapi` and `OID4VCI`.
 
-Depending on what you declared in your `acceptedProtocols` you may receive either or both as properties in the `protocols` object carried in the `request` query parameter.
+Depending on what you declared in your `acceptedProtocols` you may receive either or both as properties in the `protocols` object carried in the `request` query parameter. It is up to wallet providers to decide (or they may delegate this to advanced users) which protocol to use if multiple protocols are supported.
 
 ### VC-API
 
-The `vcapi` property will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `GET` request to this URL to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object of the response. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details.
+The `vcapi` property will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `POST` request to this URL with an empty JSON object (`{}`) to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object of the response to that `POST` request. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details.
 
 See the [VC API Specification](https://w3c-ccg.github.io/vc-api/) for more details on this protocol.
 

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -67,10 +67,9 @@ Add something similar to your registration page:
 <script src="https://unpkg.com/web-credential-handler@2/dist/web-credential-handler.min.js"></script>
 
 <script>
-  await credentialHandlerPolyfill.loadOnce();
-
   document.getElementById('installHandlerButton').addEventListener('click', async function() {
     try {
+      await credentialHandlerPolyfill.loadOnce();
       await WebCredentialHandler.installHandler();
       console.log('Handler Installed Successfully!');
     } catch (error) {
@@ -99,7 +98,7 @@ Here is an example URL showing the `request` query parameter and its URL encoded
 
 <pre><code style="white-space: normal;overflow: auto;word-break: break-word;">
 https://wallet.example.com/switchboard
-  ?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D
+?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%257B%2522credential_issuer%2522%253A%2522https%253A%252F%252Fexample.exchanger.com%252Fexchangers%252Fz1A1GqykGBWKbwhFCDqFjMfnG%252Fexchanges%252Fz1A36rr6wEL25EEiikKvisVEC%2522%252C%2522credentials%2522%253A%255B%257B%2522format%2522%253A%2522ldp_vc%2522%252C%2522credential_definition%2522%253A%257B%2522%2540context%2522%253A%255B%2522https%253A%252F%252Fwww.w3.org%252F2018%252Fcredentials%252Fv1%2522%252C%2522https%253A%252F%252Fpurl.imsglobal.org%252Fspec%252Fob%252Fv3p0%252Fcontext.json%2522%255D%252C%2522type%2522%253A%255B%2522VerifiableCredential%2522%252C%2522OpenBadgeCredential%2522%255D%257D%257D%255D%252C%2522grants%2522%253A%257B%2522urn%253Aietf%253Aparams%253Aoauth%253Agrant-type%253Apre-authorized_code%2522%253A%257B%2522pre-authorized_code%2522%253A%25220065a8a0-069b-46f1-a857-4e1ce5047afd%2522%257D%257D%257D%22%2C%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%7D%7D
 </code></pre>
 
 The `request` value is URL encoded. Its contents look like this when unencoded:
@@ -109,7 +108,7 @@ The `request` value is URL encoded. Its contents look like this when unencoded:
   "credentialRequestOrigin": "https://playground.chapi.io",
   "protocols": {
     "vcapi": "https://exchanger.example.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z19mxa763DAKX7diL51kBFecZ",
-    "OID4VCI": "openid-credential-offer://?credential_offer={"credential_issuer":"https://example.exchanger.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z1A36rr6wEL25EEiikKvisVEC","credentials":[{"format":"ldp_vc","credential_definition":{"@context":["https://www.w3.org/2018/credentials/v1","https://purl.imsglobal.org/spec/ob/v3p0/context.json"],"type":["VerifiableCredential","OpenBadgeCredential"]}}],"grants":{"urn:ietf:params:oauth:grant-type:pre-authorized_code":{"pre-authorized_code":"0065a8a0-069b-46f1-a857-4e1ce5047afd"}"
+    "OID4VCI": "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D"
   }
 }
 ```

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -21,13 +21,20 @@ permalink: /developers/wallets/native/
 
 ## Wallet Registration
 
-Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials on the Web.
+Wallets need to be registered with the browser as a Credential Handler in order to store or retrieve Verifiable Credentials (VCs) on the Web.
 
-To enable a native mobile wallet to receive VCs via CHAPI, your application will need to be able to handle deep links. Deep links, also known as app links, cause a user's Web browser to open a native application and pass the URL to it when particular links are followed. This enables the user's Web browser to open a native mobile wallet from the CHAPI wallet selection menu and pass the CHAPI request to it. See appropriate deep link documentation for [Android](https://developer.android.com/training/app-links/deep-linking) or [iOS](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content?language=objc).
+To enable a native mobile wallet to receive VCs via CHAPI, your application will need to be configured to receive deep links from the mobile OS.
 
-During this process you will be required to host the appropriate operating system specific files on a web server. To enable CHAPI registration this web server will also need to host a page that allows the user to register the CHAPI handler with the mobile web browser.
+Deep links, also known as app links, cause a user's Web browser to open a native application and pass any URL to it when particular links are followed. This enables the user's Web browser to open a native mobile wallet from the CHAPI wallet selection menu and pass the CHAPI request to it. See appropriate deep link documentation for [Android](https://developer.android.com/training/app-links/deep-linking) or [iOS](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content?language=objc).
+
+Consequently, you will be required by the mobile OS to host the appropriate operating system specific files on a Web server.
+
+In addition, to enable CHAPI registration, your Web server will also need to host a page that allows the user to register your wallet with CHAPI within their mobile Web browser.
 
 ### 1. Import the CHAPI Polyfill into the page
+
+The page that receives the deep link must include the CHAPI Polyfill to liaison
+the registration of your Native Wallet with your user's browser:
 
 ```html
 <script src="https://unpkg.com/credential-handler-polyfill@3/dist/credential-handler-polyfill.min.js"></script>
@@ -37,9 +44,9 @@ During this process you will be required to host the appropriate operating syste
 </script>
 ```
 
-### 2. Add a `credential_handler` to the server's manifest.json
+### 2. Add a `credential_handler` to the server's `manifest.json`
 
-In order to register a credential handler, your registration page's server must serve a "manifest.json" file from its root path ("/manifest.json"). This file must also be CORS-enabled. Add the following `credential_handler` object with the appropriate `acceptedProtocols` your wallet will handle:
+In order to register as a Credential Handler, your registration page's server must serve a `manifest.json` file from its root path (`/manifest.json`). This endpoint must also be CORS-enabled. Add the following `credential_handler` object with the appropriate `acceptedProtocols` your wallet can handle:
 
 ```json
 {
@@ -56,13 +63,15 @@ In order to register a credential handler, your registration page's server must 
 }
 ```
 
-The `url` property will be the entry point for your mobile wallet so it must be a deeplink that will open the application. The details about the event that initiated this action will be relayed via query parameters.
+The `url` property must be the entry point for your mobile wallet so it must be a deep link that will open the application. Details about the event that initiates the opening of this URL will be relayed via query parameters appended to it.
 
-The `acceptedInput` property is what tells CHAPI that the wallet receives data through URL and query parameters rather than events like a web wallet does.
+The `"acceptedInput": "url"` line tells CHAPI that the wallet should receive data via opening the URL and providing query parameters rather than browser sent events typically used with Web wallets.
 
-### 3. Allow your users to register their wallet's credential handler with the browser polyfill
+### 3. Allow your users to register their wallet as a Credential Handler with the browser polyfill
 
-Add to your registration page the ability for a user to register the wallet as a Credential Handler. This must be initiated by user interaction so you cannot automatically register without the user clicking a button.
+Next, we need to have the user trigger the registration of your wallet as a Credential Handler within their browser. This must be initiated by user interaction, so you cannot automatically register without the user clicking a button.
+
+Add something similar to your registration page:
 
 ```html
 <button id="installHandlerButton">Register Wallet</button>
@@ -83,7 +92,9 @@ Add to your registration page the ability for a user to register the wallet as a
 
 ### 4. Link users to the registration page from your application
 
-After this registration page is up and running your mobile application can include a link to it that will open the devices browser to the registration page and allow them to register the wallet as a Credential Handler.
+Your mobile application should include a link to your registration page. That link should open the device's default browser and allow them to register the wallet as a Credential Handler.
+
+Once done, your Wallet should now be enabled to handle various credential related requests from across the Web.
 
 ## VC Storage
 

--- a/developers/wallets/native.md
+++ b/developers/wallets/native.md
@@ -86,21 +86,41 @@ Your mobile application should include a link to your registration page. That li
 
 Once done, your Wallet should now be enabled to handle various credential related requests from across the Web.
 
-## VC Storage
+## Verifiable Credential Storage
 
-There are currently two possible protocols that issuers may use with CHAPI in order to issue Verifiable Credentials and have them stored in the user's digital wallet. When the application lands on the page specified in the `url` property of the `credential_handler` in the `manifest.json` file there will be a `request` query parameter that will include a URL encoded object with the following properties:
+Now that your native wallet has been registered with CHAPI, it can receive requests to store credentials at the URL stated in the `credential_handler.url` of the `manifest.json` above.
+
+The endpoint declared there (i.e. `/switchboard`) will receive a `request` query parameter that will include a URL encoded object with the following properties:
 
 - `credentialRequestOrigin`: This will tell the wallet where the request originated
 - `protocols`: This will include any available credential issuance protocols. The wallet may retrieve the credential for storage from any of the available protocols.
 
-Example URL that includes both `vcapi` as well as `OID4VCI` issuance protocols.
+Here is an example URL showing the `request` query parameter and its URL encoded value:
 
-`https://wallet.example.com/worker?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D`
+<pre><code style="white-space: normal;overflow: auto;word-break: break-word;">
+https://wallet.example.com/switchboard
+  ?request=%7B%22credentialRequestOrigin%22%3A%22https%3A%2F%2Fplayground.chapi.io%22%2C%22protocols%22%3A%7B%22vcapi%22%3A%22https%3A%2F%2Fexchanger.example.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz19mxa763DAKX7diL51kBFecZ%22%2C%22OID4VCI%22%3A%22openid-credential-offer%3A%2F%2F%3Fcredential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Fexample.exchanger.com%2Fexchangers%2Fz1A1GqykGBWKbwhFCDqFjMfnG%2Fexchanges%2Fz1A36rr6wEL25EEiikKvisVEC%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fpurl.imsglobal.org%2Fspec%2Fob%2Fv3p0%2Fcontext.json%22%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22OpenBadgeCredential%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%220065a8a0-069b-46f1-a857-4e1ce5047afd%22%7D%7D%7D
+</code></pre>
 
+The `request` value is URL encoded. It's contents look like this when unencoded:
+
+```json
+{
+  "credentialRequestOrigin": "https://playground.chapi.io",
+  "protocols": {
+    "vcapi": "https://exchanger.example.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z19mxa763DAKX7diL51kBFecZ",
+    "OID4VCI": "openid-credential-offer://?credential_offer={"credential_issuer":"https://example.exchanger.com/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z1A36rr6wEL25EEiikKvisVEC","credentials":[{"format":"ldp_vc","credential_definition":{"@context":["https://www.w3.org/2018/credentials/v1","https://purl.imsglobal.org/spec/ob/v3p0/context.json"],"type":["VerifiableCredential","OpenBadgeCredential"]}}],"grants":{"urn:ietf:params:oauth:grant-type:pre-authorized_code":{"pre-authorized_code":"0065a8a0-069b-46f1-a857-4e1ce5047afd"}"
+  }
+}
+```
+
+There are currently two possible protocols that Issuers may use with CHAPI in order to issue Verifiable Credentials to be stored in the user's digital wallet: `vcapi` and `OID4VCI`.
+
+Depending on what you declared in your `acceptedProtocols` you may receive either or both as properties in the `protocols` object carried in the `request` query parameter.
 
 ### VC-API
 
-If the protocols property from the request contains a `vcapi` property it will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `GET` request to this URL to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details. 
+The `vcapi` property will be a URL that will tell the wallet where to go to retrieve the credential. The wallet can send a `GET` request to this URL to attempt to download the VC to be stored. The VC will be found in the `verifiablePresentation` object of the response. If there are further steps required in the flow such as DID Auth a `verifiablePresentationRequest` object will describe the details.
 
 See the [VC API Specification](https://w3c-ccg.github.io/vc-api/) for more details on this protocol.
 
@@ -109,7 +129,9 @@ Example VCAPI protocol URL:
 
 ### OID4VCI
 
-If the protocols property from the request contains a `OID4VCI` property it will be a URL that will include all of the required information to complete the issuance of the Verifiable Credential using the OID4VCI protocol. See the [OID4VCI Specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) for more details of this protocol.
+The `OID4VCI` property will be a URL that includes all of the required information to complete the issuance of the Verifiable Credential using the OID4VCI protocol.
+
+See the [OID4VCI Specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) for more details of this protocol.
 
 Example OID4VCI protocol URL:
 `openid-credential-offer://?credential_offer={"credential_issuer":"https://qa.veresexchanger.dev/exchangers/z1A1GqykGBWKbwhFCDqFjMfnG/exchanges/z1A36rr6wEL25EEiikKvisVEC","credentials":[{"format":"ldp_vc","credential_definition":{"@context":["https://www.w3.org/2018/credentials/v1","https://purl.imsglobal.org/spec/ob/v3p0/context.json"],"type":["VerifiableCredential","OpenBadgeCredential"]}}],"grants":{"urn:ietf:params:oauth:grant-type:pre-authorized_code":{"pre-authorized_code":"0065a8a0-069b-46f1-a857-4e1ce5047afd"}}}`


### PR DESCRIPTION
Continuing from #25, but now with wallet docs split in two pages and based on latest 11ty code.

TODO:
> We should be clear that there are two ways to receive requests from CHAPI, one is via CHAPI events and the other via URLs (which can be deep / "app" links). Your credential handler registers to work with just one of these mechanisms, not both.
> https://github.com/credential-handler/chapi.io/pull/25#pullrequestreview-1587821284