### PR TITLE
Improve home page text

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,11 +5,9 @@ permalink: /index.html
 showHero: true
 ---
 
-The CHAPI protocol allows your digital wallet to receive Verifiable Credentials from an independent third-party issuer - or present Verifiable Credentials to an independent third-party verifier - in a way that establishes trust and preserves privacy.
-## CHAPI is for open for _everyone_
-CHAPI is an open protocol designed to solve the "NASCAR Problem" - too often, users are presented with a fixed set of options for authentication with third-party sites.  The CHAPI protocol provides mediation between any CHAPI-enabled web application and a third-party site.  Just register your web app with your browser, and off you go!
+The Credential Handler API (CHAPI) allows your digital wallet to receive [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) from an independent third-party issuer - or present Verifiable Credentials to an independent third-party verifier - in a way that establishes trust and preserves privacy.
 
-Both [CHAPI](https://w3c-ccg.github.io/credential-handler-api/) and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) are results of open collaboration through World Wide Web Consortium (W3C).  You can find more information and join the discussion at the [W3C Credentials Community Group](https://www.w3.org/community/credentials/).
+Too often, users are presented with a fixed set of options for authentication with third-party sites. The CHAPI protocol provides mediation between any CHAPI-enabled Web or mobile application and a third-party site.
 
 ## How does CHAPI work?
 A _Credential Handler_ is an event handler for credential request and storage events.  Web app developers can use CHAPI to provide their users with Credential Handlers that run in the browser.  These Credential Handlers can respond when users visit other websites that present, request, or store Verifiable Credentials.
@@ -30,5 +28,7 @@ Interested in making your Verifier/Issuer/Wallet available for experimentation? 
 <p class="button-row">
     <a href="developers/playgroundfaq" class="btn2">CHAPI Playground FAQ</a>
 </p>
+
+[CHAPI](https://w3c-ccg.github.io/credential-handler-api/) and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) are the result of open collaboration through the World Wide Web Consortium (W3C).  You can find more information and join the discussion at the [W3C Credentials Community Group](https://www.w3.org/community/credentials/).
 
 Read more about the [open standards that power CHAPI](/standards).

--- a/index.md
+++ b/index.md
@@ -13,8 +13,9 @@ Too often, users are presented with a fixed set of options for authentication wi
 A _Credential Handler_ is an event handler for credential request and storage events.  Web app developers can use CHAPI to provide their users with Credential Handlers that run in the browser.  These Credential Handlers can respond when users visit other websites that present, request, or store Verifiable Credentials.
 
 ![Choose a wallet modal presenting all preregistered wallet systems which can be clicked on to proceed to store the credentials there.](/images/VeresCHAPIaccept.png)
-## How do I build CHAPI into my website or application?
-Examples and developer docs:
+
+## Enable Browser-based Credential Exchange
+Checkout the examples and developer docs...
 
 <p class="button-row">
     <a href="developers/issuers" class="btn2">for VC Issuers</a>

--- a/index.md
+++ b/index.md
@@ -23,11 +23,11 @@ Checkout the examples and developer docs...
     <a href="developers/verifiers" class="btn2">for VC Verifiers </a>
 </p>
 
-## How do I integrate my application into the CHAPI Playground?
-Interested in making your Verifier/Issuer/Wallet available for experimentation?  See the Integration Guide and FAQ for the CHAPI Playground.
+## Join the Verifiable Credential Playground
+Interested in making your Verifier/Issuer/Wallet available for experimentation?  See the Integration Guide and FAQ for the [Verifiable Credential Playground](https://vcplayground.org/).
 
 <p class="button-row">
-    <a href="developers/playgroundfaq" class="btn2">CHAPI Playground FAQ</a>
+    <a href="developers/playgroundfaq" class="btn2">VC Playground FAQ</a>
 </p>
 
 [CHAPI](https://w3c-ccg.github.io/credential-handler-api/) and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) are the result of open collaboration through the World Wide Web Consortium (W3C).  You can find more information and join the discussion at the [W3C Credentials Community Group](https://www.w3.org/community/credentials/).


### PR DESCRIPTION
The intro here has been bothering me for years--especially the double "for" in "CHAPI is for open for _everyone_". 😉 

This tightens up the intro a bit and focus the call to action while also widening the interest beyond just Web developers to include mobile developers also (huzzah!).